### PR TITLE
fix: Add ongoing_tournaments field to tournament list endpoint

### DIFF
--- a/coreApi/views.py
+++ b/coreApi/views.py
@@ -220,22 +220,30 @@ def logout_view(req):
 @api_view(['GET'])
 def tournament_list(request):
     """
-    Get a list of upcoming and past tournaments.
+    Get a list of upcoming, ongoing, and past tournaments.
     
-    This endpoint provides lists of upcoming tournaments (start date in the future)
-    and past tournaments (end date in the past), limited to 4 of each.
+    This endpoint provides lists of upcoming tournaments (start date in the future),
+    ongoing tournaments (current date between start and end date), and past tournaments
+    (end date in the past), limited to 4 of each.
     
     HTTP Method: GET
     
     Returns:
         Response: JSON containing:
         - upcoming_tournaments: List of tournaments with future start dates (max 4)
+        - ongoing_tournaments: List of tournaments currently in progress (max 4)
         - past_tournaments: List of tournaments with past end dates (max 4)
     """
     current_date = timezone.now().date()
-      # Get upcoming tournaments
+    # Get upcoming tournaments
     upcoming_tournaments = Tournament.objects.filter(
         start_date__gt=current_date
+    ).select_related('organization', 'sport').order_by('start_date')[:4]
+    
+    # Get ongoing tournaments
+    ongoing_tournaments = Tournament.objects.filter(
+        start_date__lte=current_date,
+        end_date__gte=current_date
     ).select_related('organization', 'sport').order_by('start_date')[:4]
     
     # Get past tournaments
@@ -245,10 +253,12 @@ def tournament_list(request):
     
     # Serialize the data
     upcoming_serializer = TournamentListSerializer(upcoming_tournaments, many=True)
+    ongoing_serializer = TournamentListSerializer(ongoing_tournaments, many=True)
     past_serializer = TournamentListSerializer(past_tournaments, many=True)
     
     return Response({
         'upcoming_tournaments': upcoming_serializer.data,
+        'ongoing_tournaments': ongoing_serializer.data,
         'past_tournaments': past_serializer.data
     })
 

--- a/docs/core_api.md
+++ b/docs/core_api.md
@@ -195,9 +195,9 @@ This document details the endpoints available in the Core API.
 
 ## Tournaments
 
-### List Upcoming and Past Tournaments
+### List Upcoming, Ongoing, and Past Tournaments
 
--   **Description:** Retrieves a list of upcoming and past tournaments.
+-   **Description:** Retrieves lists of upcoming tournaments (future start dates), ongoing tournaments (current date between start and end date), and past tournaments (past end dates), limited to 4 of each.
 -   **Endpoint:** `/upcoming-past_tournaments/`
 -   **Method:** `GET`
 -   **Success Response (200 OK):**
@@ -218,6 +218,23 @@ This document details the endpoints available in the Core API.
                 "start_day_date": "01",
                 "card_details": "Starts on September 1, 2025",
                 "end_date_": "September 5, 2025"
+            }
+        ],
+        "ongoing_tournaments": [
+            {
+                "id": 3,
+                "name": "Spring Tournament",
+                "organization": {
+                    "name": "Sports Org"
+                },
+                "start_date": "2025-01-10",
+                "end_date": "2025-01-20",
+                "venue_address": "789 Park Blvd, Anytown, USA",
+                "completed": false,
+                "start_month": "Jan",
+                "start_day_date": "10",
+                "card_details": "Ongoing until January 20, 2025",
+                "end_date_": "January 20, 2025"
             }
         ],
         "past_tournaments": [

--- a/docs/playportal-endpoints.json
+++ b/docs/playportal-endpoints.json
@@ -301,7 +301,7 @@
           "name": "Tournaments",
           "item": [
             {
-              "name": "Get Tournament List (Upcoming & Past)",
+              "name": "Get Tournament List (Upcoming, Ongoing & Past)",
               "request": {
                 "method": "GET",
                 "header": [],
@@ -310,7 +310,7 @@
                   "host": ["{{base_url}}"],
                   "path": ["upcoming-past_tournaments", ""]
                 },
-                "description": "Get lists of upcoming tournaments (future start dates) and past tournaments (past end dates), limited to 4 of each."
+                "description": "Get lists of upcoming tournaments (future start dates), ongoing tournaments (current date between start and end date), and past tournaments (past end dates), limited to 4 of each."
               },
               "response": [
                 {
@@ -329,7 +329,7 @@
                   "_postman_previewlanguage": "json",
                   "header": [],
                   "cookie": [],
-                  "body": "{\n    \"upcoming_tournaments\": [\n        {\n            \"id\": 1,\n            \"name\": \"Summer Championship 2025\",\n            \"organization\": {\n                \"name\": \"Sports Club Delhi\"\n            },\n            \"start_date\": \"2025-09-15\",\n            \"end_date\": \"2025-09-17\",\n            \"venue_address\": \"Delhi Sports Complex\",\n            \"completed\": false\n        }\n    ],\n    \"past_tournaments\": [\n        {\n            \"id\": 2,\n            \"name\": \"Winter Cup 2024\",\n            \"organization\": {\n                \"name\": \"Mumbai Sports Association\"\n            },\n            \"start_date\": \"2024-12-01\",\n            \"end_date\": \"2024-12-03\",\n            \"venue_address\": \"Mumbai Stadium\",\n            \"completed\": true\n        }\n    ]\n}"
+                  "body": "{\n    \"upcoming_tournaments\": [\n        {\n            \"id\": 1,\n            \"name\": \"Summer Championship 2025\",\n            \"organization\": {\n                \"name\": \"Sports Club Delhi\"\n            },\n            \"start_date\": \"2025-09-15\",\n            \"end_date\": \"2025-09-17\",\n            \"venue_address\": \"Delhi Sports Complex\",\n            \"completed\": false\n        }\n    ],\n    \"ongoing_tournaments\": [\n        {\n            \"id\": 3,\n            \"name\": \"Spring Tournament 2025\",\n            \"organization\": {\n                \"name\": \"Chennai Sports Club\"\n            },\n            \"start_date\": \"2025-01-10\",\n            \"end_date\": \"2025-01-20\",\n            \"venue_address\": \"Chennai Sports Arena\",\n            \"completed\": false\n        }\n    ],\n    \"past_tournaments\": [\n        {\n            \"id\": 2,\n            \"name\": \"Winter Cup 2024\",\n            \"organization\": {\n                \"name\": \"Mumbai Sports Association\"\n            },\n            \"start_date\": \"2024-12-01\",\n            \"end_date\": \"2024-12-03\",\n            \"venue_address\": \"Mumbai Stadium\",\n            \"completed\": true\n        }\n    ]\n}"
                 }
               ]
             },


### PR DESCRIPTION
## Description
This PR adds the `ongoing_tournaments` field to the tournament list endpoint to return tournaments that are currently in progress.

## Changes
- Added `ongoing_tournaments` query to filter tournaments where current date is between `start_date` and `end_date`
- Updated `tournament_list` endpoint to return three lists: upcoming, ongoing, and past tournaments (max 4 each)
- Updated documentation in `core_api.md` and `playportal-endpoints.json` to reflect the new field

## Testing
- Endpoint now returns `ongoing_tournaments` array alongside `upcoming_tournaments` and `past_tournaments`
- All three lists are limited to 4 items each
- Ongoing tournaments are correctly filtered based on current date being between start and end dates